### PR TITLE
Load DATABASE_URL from dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ Clone this repository and install its dependencies:
 pip install -r requirements.txt
 ```
 
-Create a `.env` file in the project root with your API keys:
+Create a `.env` file in the project root with your API keys and database connection string:
 
 ```dotenv
 PERPLEXITY_API_KEY=pk-xxxxxxxxxxxxxxxx
 MEDIUM_TOKEN=xxxxxxxxxxxxxxxx
+DATABASE_URL=postgresql://user:password@neonhost/neondb
 ```
+
+`DATABASE_URL` should be the full connection string from your [Neon](https://neon.tech) Postgres dashboard.
+Never commit this file to version control; it is already ignored via `.gitignore`.
 
 Alternatively, you can pass keys using `--pplx-key` and `--medium-token` when
 running the CLI.

--- a/app/db.py
+++ b/app/db.py
@@ -21,6 +21,13 @@ from sqlalchemy import (
 )
 from sqlalchemy.engine import Engine
 
+try:
+    from dotenv import load_dotenv  # type: ignore
+except ImportError:
+    def load_dotenv(*args: Any, **kwargs: Any) -> None:
+        """Fallback no-op when python-dotenv is not installed."""
+        return None  # type: ignore
+
 DATABASE_URL_ENV = "DATABASE_URL"
 
 metadata = MetaData()
@@ -47,6 +54,7 @@ articles = Table(
 
 def get_engine(db_url: Optional[str] = None, *, echo: bool = False) -> Engine:
     """Return a SQLAlchemy engine using DATABASE_URL env var or provided string."""
+    load_dotenv()
     url = db_url or os.getenv(DATABASE_URL_ENV)
     if not url:
         raise ValueError("A database URL must be provided via argument or DATABASE_URL")


### PR DESCRIPTION
## Summary
- load DATABASE_URL using python-dotenv in the database module
- document Neon Postgres DATABASE_URL setup in README

## Testing
- `pytest`
- `python -m app.cli --help`


------
https://chatgpt.com/codex/tasks/task_e_689776c2a410832d9cef17bd16ac9af9