### PR TITLE
Add SQL migration and Neon setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ Never commit this file to version control; it is already ignored via `.gitignore
 Alternatively, you can pass keys using `--pplx-key` and `--medium-token` when
 running the CLI.
 
+### Run database migrations
+
+Create the required tables in your Neon Postgres database using the bundled SQL
+migration. The command below applies all migrations found in `db/migrations`
+using the [yoyo-migrations](https://ollycope.com/software/yoyo/latest/)
+tool installed from `requirements.txt`:
+
+```bash
+yoyo apply --database "$DATABASE_URL" db/migrations
+```
+
+`DATABASE_URL` should be the same connection string from your Neon dashboard.
+With the tables in place you can start planning articles.
+
 ### Plan an article
 
 Use the `plan` subcommand to insert a topic into the database. Optionally
@@ -84,6 +98,8 @@ auto_blog/
 │   ├── medium_publisher.py      # wrapper around Medium API
 │   ├── db.py                    # simple SQLAlchemy helpers
 │   └── cli.py                   # command line interface
+├── db/
+│   └── migrations/          # SQL schema migrations
 ├── README.md                # this file
 └── requirements.txt         # pip dependencies
 ```

--- a/db/migrations/001_create_tables.sql
+++ b/db/migrations/001_create_tables.sql
@@ -1,0 +1,21 @@
+-- Create initial tables for auto_blog
+CREATE TABLE series (
+    id SERIAL PRIMARY KEY,
+    topic VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE articles (
+    id SERIAL PRIMARY KEY,
+    topic VARCHAR NOT NULL,
+    status VARCHAR NOT NULL,
+    markdown TEXT,
+    series_id INTEGER REFERENCES series(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    scheduled_at TIMESTAMPTZ
+);
+
+-- //@UNDO
+
+DROP TABLE articles;
+DROP TABLE series;

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 python-dotenv
 sqlalchemy
 psycopg[binary]
+yoyo-migrations


### PR DESCRIPTION
## Summary
- add initial SQL migration for `series` and `articles` tables
- document running migrations against Neon using yoyo-migrations
- include yoyo-migrations in dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement yoyo-migrations)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897795963d0832db1edece9719ab789