### PR TITLE
feat: add series plan generation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,13 +14,19 @@ This package exposes two main classes:
     :mod:`.medium_publisher` for details.
 """
 
-from .perplexity_generator import PerplexityGenerator, PerplexityError, PerpModel
+from .perplexity_generator import (
+    PerplexityGenerator,
+    PerplexityError,
+    PerpModel,
+    generate_series_plan,
+)
 from .medium_publisher import MediumPublisher, MediumError, PublishStatus
 
 __all__ = [
     "PerplexityGenerator",
     "PerplexityError",
     "PerpModel",
+    "generate_series_plan",
     "MediumPublisher",
     "MediumError",
     "PublishStatus",


### PR DESCRIPTION
## Summary
- add `generate_series_plan` API to create standalone post ideas
- expose `generate_series_plan` at package level

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689782e1d4c8832da4e8af2259b364f8