### PR TITLE
Fix workflow paths

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r medium_auto_article/requirements.txt
+          pip install -r requirements.txt
 
       - name: Generate (and optionally publish) article
         shell: bash
@@ -115,7 +115,7 @@ jobs:
           fi
 
           # Run the Python CLI to generate the article (and publish if requested).
-          python -m medium_auto_article.cli \
+          python -m app.cli \
             --topic "$TOPIC" \
             --audience "$AUDIENCE" \
             --tone "$TONE" \


### PR DESCRIPTION
## Summary
- fix requirements path in auto_article workflow
- invoke app.cli in GitHub Actions workflow

## Testing
- `python -m app.cli --help`

------
https://chatgpt.com/codex/tasks/task_e_6897a7b897b8832d93c0855afd00f4a2