### PR TITLE
Cache pip dependencies in workflow

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -75,8 +75,17 @@ jobs:
 
       - name: Set up Python
         uses: actions/setup-python@v4
+        id: setup-python
         with:
           python-version: '3.11'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary
- cache pip dependencies in GitHub Actions using actions/cache keyed by Python version and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_6897a89df0cc832d8eda83065d7928c0