### PR TITLE
Split auto article workflow for manual and scheduled runs

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -1,0 +1,113 @@
+name: Generate Article
+description: 'Set up Python and generate Medium article'
+inputs:
+  topic:
+    description: 'Topic of the article'
+    required: false
+    default: 'Serverless computing in India: pros and cons'
+  publish:
+    description: 'Publish to Medium (true|false)'
+    required: false
+    default: 'false'
+  tags:
+    description: 'Comma-separated tags (max 5)'
+    required: false
+    default: ''
+  audience:
+    description: 'Audience level (beginner|intermediate|advanced)'
+    required: false
+    default: 'beginner'
+  tone:
+    description: 'Tone (friendly|professional|practical|conversational)'
+    required: false
+    default: 'practical'
+  model:
+    description: 'Perplexity model (sonar|sonar-reasoning|sonar-pro|sonar-deep-research)'
+    required: false
+    default: 'sonar'
+  minutes:
+    description: 'Estimated reading time'
+    required: false
+    default: '10'
+  outline_depth:
+    description: 'Outline depth (integer)'
+    required: false
+    default: '3'
+  include_code:
+    description: 'Include code snippets? (true|false)'
+    required: false
+    default: 'true'
+  status:
+    description: 'Medium publish status (draft|public|unlisted)'
+    required: false
+    default: 'draft'
+  canonical_url:
+    description: 'Canonical URL (optional)'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      id: setup-python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Cache pip dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Generate (and optionally publish) article
+      shell: bash
+      run: |
+        TOPIC="${{ inputs.topic }}"
+        AUDIENCE="${{ inputs.audience }}"
+        TONE="${{ inputs.tone }}"
+        MODEL="${{ inputs.model }}"
+        MINUTES="${{ inputs.minutes }}"
+        OUTLINE_DEPTH="${{ inputs.outline_depth }}"
+        INCLUDE_CODE="${{ inputs.include_code }}"
+        TAGS="${{ inputs.tags }}"
+        PUBLISH="${{ inputs.publish }}"
+        STATUS="${{ inputs.status }}"
+        CANONICAL_URL="${{ inputs.canonical_url }}"
+
+        CODE_FLAG=""
+        if [ "$INCLUDE_CODE" = "false" ]; then
+          CODE_FLAG="--no-code"
+        fi
+        PUBLISH_FLAG=""
+        if [ "$PUBLISH" = "true" ]; then
+          PUBLISH_FLAG="--publish --status $STATUS"
+        fi
+        TAGS_ARG=""
+        if [ -n "$TAGS" ]; then
+          TAGS_ARG="--tags $(echo $TAGS | tr ',' ' ')"
+        fi
+
+        python -m app.cli \
+          --topic "$TOPIC" \
+          --audience "$AUDIENCE" \
+          --tone "$TONE" \
+          --model "$MODEL" \
+          --minutes "$MINUTES" \
+          --outline-depth "$OUTLINE_DEPTH" \
+          $CODE_FLAG \
+          $PUBLISH_FLAG \
+          --canonical-url "$CANONICAL_URL" \
+          $TAGS_ARG
+

--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -63,75 +63,33 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  generate:
+  autopilot:
+    if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
-      # Secrets configured in repository settings for API keys
       PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
       MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: ./.github/actions/generate
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        id: setup-python
+  manual:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+      MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
+    steps:
+      - uses: ./.github/actions/generate
         with:
-          python-version: '3.11'
+          topic: ${{ github.event.inputs.topic }}
+          publish: ${{ github.event.inputs.publish }}
+          tags: ${{ github.event.inputs.tags }}
+          audience: ${{ github.event.inputs.audience }}
+          tone: ${{ github.event.inputs.tone }}
+          model: ${{ github.event.inputs.model }}
+          minutes: ${{ github.event.inputs.minutes }}
+          outline_depth: ${{ github.event.inputs.outline_depth }}
+          include_code: ${{ github.event.inputs.include_code }}
+          status: ${{ github.event.inputs.status }}
+          canonical_url: ${{ github.event.inputs.canonical_url }}
 
-      - name: Cache pip dependencies
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Generate (and optionally publish) article
-        shell: bash
-        run: |
-          # Determine input values, falling back to defaults where necessary.
-          TOPIC="${{ github.event.inputs.topic || 'Serverless computing in India: pros and cons' }}"
-          AUDIENCE="${{ github.event.inputs.audience || 'beginner' }}"
-          TONE="${{ github.event.inputs.tone || 'practical' }}"
-          MODEL="${{ github.event.inputs.model || 'sonar' }}"
-          MINUTES="${{ github.event.inputs.minutes || '10' }}"
-          OUTLINE_DEPTH="${{ github.event.inputs.outline_depth || '3' }}"
-          INCLUDE_CODE="${{ github.event.inputs.include_code || 'true' }}"
-          TAGS="${{ github.event.inputs.tags || '' }}"
-          PUBLISH="${{ github.event.inputs.publish || 'false' }}"
-          STATUS="${{ github.event.inputs.status || 'draft' }}"
-          CANONICAL_URL="${{ github.event.inputs.canonical_url || '' }}"
-
-          # Build optional flags for the CLI.
-          CODE_FLAG=""
-          if [ "$INCLUDE_CODE" = "false" ]; then
-            CODE_FLAG="--no-code"
-          fi
-          PUBLISH_FLAG=""
-          if [ "$PUBLISH" = "true" ]; then
-            PUBLISH_FLAG="--publish --status $STATUS"
-          fi
-          TAGS_ARG=""
-          if [ -n "$TAGS" ]; then
-            # Convert comma‑separated list into space‑separated arguments
-            TAGS_ARG="--tags $(echo $TAGS | tr ',' ' ')"
-          fi
-
-          # Run the Python CLI to generate the article (and publish if requested).
-          python -m app.cli \
-            --topic "$TOPIC" \
-            --audience "$AUDIENCE" \
-            --tone "$TONE" \
-            --model "$MODEL" \
-            --minutes "$MINUTES" \
-            --outline-depth "$OUTLINE_DEPTH" \
-            $CODE_FLAG \
-            $PUBLISH_FLAG \
-            --canonical-url "$CANONICAL_URL" \
-            $TAGS_ARG


### PR DESCRIPTION
## Summary
- split article workflow into separate `autopilot` (schedule) and `manual` jobs
- add composite action to share article generation steps and default inputs

## Testing
- `yamllint .github/workflows/auto_article.yml .github/actions/generate/action.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897a9d4eabc832d9fbce6f058e0f16a