### PR TITLE
Refine workflow dispatch inputs and document manual triggers

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -16,46 +16,75 @@ on:
       topic:
         description: 'Topic of the article'
         required: false
+        type: string
         default: 'Serverless computing in India: pros and cons'
       publish:
-        description: 'Publish to Medium (true|false)'
+        description: 'Publish to Medium?'
         required: false
-        default: 'false'
+        type: boolean
+        default: false
       tags:
         description: 'Comma‑separated tags (max 5)'
         required: false
+        type: string
         default: ''
       audience:
-        description: 'Audience level (beginner|intermediate|advanced)'
+        description: 'Audience level'
         required: false
-        default: 'beginner'
+        type: choice
+        default: beginner
+        options:
+          - beginner
+          - intermediate
+          - advanced
       tone:
-        description: 'Tone (friendly|professional|practical|conversational)'
+        description: 'Tone'
         required: false
-        default: 'practical'
+        type: choice
+        default: practical
+        options:
+          - friendly
+          - professional
+          - practical
+          - conversational
       model:
-        description: 'Perplexity model (sonar|sonar-reasoning|sonar-pro|sonar-deep-research)'
+        description: 'Perplexity model'
         required: false
-        default: 'sonar'
+        type: choice
+        default: sonar
+        options:
+          - sonar
+          - sonar-reasoning
+          - sonar-pro
+          - sonar-deep-research
       minutes:
         description: 'Estimated reading time'
         required: false
-        default: '10'
+        type: number
+        default: 10
       outline_depth:
         description: 'Outline depth (integer)'
         required: false
-        default: '3'
+        type: number
+        default: 3
       include_code:
-        description: 'Include code snippets? (true|false)'
+        description: 'Include code snippets?'
         required: false
-        default: 'true'
+        type: boolean
+        default: true
       status:
-        description: 'Medium publish status (draft|public|unlisted)'
+        description: 'Medium publish status'
         required: false
-        default: 'draft'
+        type: choice
+        default: draft
+        options:
+          - draft
+          - public
+          - unlisted
       canonical_url:
         description: 'Canonical URL (optional)'
         required: false
+        type: string
         default: ''
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ jobs:
 
 Store credentials as repository secrets under *Settings → Secrets and variables → Actions*.
 
+Trigger the workflow manually from the GitHub mobile app by opening the repository, tapping **Actions**, choosing **Auto Article Generator**, and selecting **Run workflow** to supply inputs.
+
+From the command line, the same can be done with the GitHub CLI:
+
+```bash
+gh workflow run auto_article.yml -f topic='My new article' -f publish=true
+```
+
 ## Cloudflare Workflows
 
 Deploy the generator as a container job using [Cloudflare Workflows](https://developers.cloudflare.com/workflows/):


### PR DESCRIPTION
## Summary
- specify types and choices for `workflow_dispatch` inputs in `auto_article.yml`
- add README guidance for triggering the workflow via GitHub Mobile and the `gh` CLI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ad456ac4832d827d1d6e01ae431b