### PR TITLE
fix workflow topic quoting

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -102,7 +102,7 @@ jobs:
       - uses: ./.github/actions/generate
         if: github.event_name != 'workflow_dispatch'
         with:
-          topic: ${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}
+          topic: "${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}"
           publish: ${{ vars.AUTO_PUBLISH || 'false' }}
           tags: ${{ vars.AUTO_TAGS || '' }}
           audience: ${{ vars.AUTO_AUDIENCE || 'beginner' }}


### PR DESCRIPTION
## Summary
- quote default topic value in auto_article workflow to prevent YAML parsing issues

## Testing
- `yamllint .github/workflows/auto_article.yml` *(fails: command not found; installation attempt blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6897af94fd54832dae263cca7950bdb6