### PR TITLE
chore: tidy CI workflows

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -49,7 +49,7 @@ runs:
   using: 'composite'
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python
       id: setup-python
@@ -58,7 +58,7 @@ runs:
         python-version: '3.11'
 
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -100,7 +100,6 @@ jobs:
       MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
     steps:
       - uses: ./.github/actions/generate
-        if: github.event_name != 'workflow_dispatch'
         with:
           topic: "${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}"
           publish: ${{ vars.AUTO_PUBLISH || 'false' }}
@@ -122,7 +121,6 @@ jobs:
       MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
     steps:
       - uses: ./.github/actions/generate
-        if: github.event_name == 'workflow_dispatch'
         with:
           topic: ${{ github.event.inputs.topic }}
           publish: ${{ github.event.inputs.publish }}


### PR DESCRIPTION
## Summary
- update custom composite action to use checkout@v4 and cache@v4
- simplify auto_article workflow by dropping redundant step conditions

## Testing
- `actionlint .github/workflows/auto_article.yml .github/actions/generate/action.yml` *(fails: command not found)*
- `yamllint .github/workflows/auto_article.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897b340c144832dbbd70d207a9c4cb4