### PR TITLE
refactor: modularize article generation workflow

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -1,135 +1,26 @@
 name: Auto Article Generator
 
-# This workflow generates a Medium article using the Perplexity API and optionally
-# publishes it via the Medium API. It runs on a fixed daily schedule and
-# provides a manual trigger with inputs for full customisation. Secrets for
-# PERPLEXITY_API_KEY and MEDIUM_TOKEN should be configured in the repository
-# settings. Default values can be supplied via repository variables or by
-# editing the defaults below.
-
 on:
   schedule:
-    # Daily at 06:00 UTC (adjust as needed).
     - cron: '0 6 * * *'
-  workflow_dispatch:
-    inputs:
-      topic:
-        description: 'Topic of the article'
-        required: false
-        type: string
-        default: 'Serverless computing in India: pros and cons'
-      publish:
-        description: 'Publish to Medium?'
-        required: false
-        type: boolean
-        default: false
-      tags:
-        description: 'Comma‑separated tags (max 5)'
-        required: false
-        type: string
-        default: ''
-      audience:
-        description: 'Audience level'
-        required: false
-        type: choice
-        default: beginner
-        options:
-          - beginner
-          - intermediate
-          - advanced
-      tone:
-        description: 'Tone'
-        required: false
-        type: choice
-        default: practical
-        options:
-          - friendly
-          - professional
-          - practical
-          - conversational
-      model:
-        description: 'Perplexity model'
-        required: false
-        type: choice
-        default: sonar
-        options:
-          - sonar
-          - sonar-reasoning
-          - sonar-pro
-          - sonar-deep-research
-      minutes:
-        description: 'Estimated reading time'
-        required: false
-        type: number
-        default: 10
-      outline_depth:
-        description: 'Outline depth (integer)'
-        required: false
-        type: number
-        default: 3
-      include_code:
-        description: 'Include code snippets?'
-        required: false
-        type: boolean
-        default: true
-      status:
-        description: 'Medium publish status'
-        required: false
-        type: choice
-        default: draft
-        options:
-          - draft
-          - public
-          - unlisted
-      canonical_url:
-        description: 'Canonical URL (optional)'
-        required: false
-        type: string
-        default: ''
 
 concurrency:
   group: auto-article
   cancel-in-progress: false
 
 jobs:
-  autopilot:
-    if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    env:
-      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-      MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
-    steps:
-      - uses: ./.github/actions/generate
-        with:
-          topic: "${{ env.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}"
-          publish: ${{ env.AUTO_PUBLISH || 'false' }}
-          tags: ${{ env.AUTO_TAGS || '' }}
-          audience: ${{ env.AUTO_AUDIENCE || 'beginner' }}
-          tone: ${{ env.AUTO_TONE || 'practical' }}
-          model: ${{ env.AUTO_MODEL || 'sonar' }}
-          minutes: ${{ env.AUTO_MINUTES || '10' }}
-          outline_depth: ${{ env.AUTO_OUTLINE_DEPTH || '3' }}
-          include_code: ${{ env.AUTO_INCLUDE_CODE || 'true' }}
-          status: ${{ env.AUTO_STATUS || 'draft' }}
-          canonical_url: ${{ env.AUTO_CANONICAL_URL || '' }}
-
-  manual:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    env:
-      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-      MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
-    steps:
-      - uses: ./.github/actions/generate
-        with:
-          topic: ${{ github.event.inputs.topic }}
-          publish: ${{ github.event.inputs.publish }}
-          tags: ${{ github.event.inputs.tags }}
-          audience: ${{ github.event.inputs.audience }}
-          tone: ${{ github.event.inputs.tone }}
-          model: ${{ github.event.inputs.model }}
-          minutes: ${{ github.event.inputs.minutes }}
-          outline_depth: ${{ github.event.inputs.outline_depth }}
-          include_code: ${{ github.event.inputs.include_code }}
-          status: ${{ github.event.inputs.status }}
-          canonical_url: ${{ github.event.inputs.canonical_url }}
+  generate:
+    uses: ./.github/workflows/generate.yml
+    secrets: inherit
+    with:
+      topic: ${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}
+      publish: ${{ vars.AUTO_PUBLISH || false }}
+      tags: ${{ vars.AUTO_TAGS || '' }}
+      audience: ${{ vars.AUTO_AUDIENCE || 'beginner' }}
+      tone: ${{ vars.AUTO_TONE || 'practical' }}
+      model: ${{ vars.AUTO_MODEL || 'sonar' }}
+      minutes: ${{ vars.AUTO_MINUTES || 10 }}
+      outline_depth: ${{ vars.AUTO_OUTLINE_DEPTH || 3 }}
+      include_code: ${{ vars.AUTO_INCLUDE_CODE || true }}
+      status: ${{ vars.AUTO_STATUS || 'draft' }}
+      canonical_url: ${{ vars.AUTO_CANONICAL_URL || '' }}

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,81 @@
+name: Generate Article
+
+on:
+  workflow_call:
+    inputs:
+      topic:
+        description: 'Topic of the article'
+        required: false
+        type: string
+        default: 'Serverless computing in India: pros and cons'
+      publish:
+        description: 'Publish to Medium?'
+        required: false
+        type: boolean
+        default: false
+      tags:
+        description: 'Comma-separated tags (max 5)'
+        required: false
+        type: string
+        default: ''
+      audience:
+        description: 'Audience level'
+        required: false
+        type: string
+        default: beginner
+      tone:
+        description: 'Tone'
+        required: false
+        type: string
+        default: practical
+      model:
+        description: 'Perplexity model'
+        required: false
+        type: string
+        default: sonar
+      minutes:
+        description: 'Estimated reading time'
+        required: false
+        type: number
+        default: 10
+      outline_depth:
+        description: 'Outline depth (integer)'
+        required: false
+        type: number
+        default: 3
+      include_code:
+        description: 'Include code snippets?'
+        required: false
+        type: boolean
+        default: true
+      status:
+        description: 'Medium publish status'
+        required: false
+        type: string
+        default: draft
+      canonical_url:
+        description: 'Canonical URL (optional)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    env:
+      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+      MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
+    steps:
+      - uses: ./.github/actions/generate
+        with:
+          topic: ${{ inputs.topic }}
+          publish: ${{ inputs.publish }}
+          tags: ${{ inputs.tags }}
+          audience: ${{ inputs.audience }}
+          tone: ${{ inputs.tone }}
+          model: ${{ inputs.model }}
+          minutes: ${{ inputs.minutes }}
+          outline_depth: ${{ inputs.outline_depth }}
+          include_code: ${{ inputs.include_code }}
+          status: ${{ inputs.status }}
+          canonical_url: ${{ inputs.canonical_url }}

--- a/.github/workflows/manual_article.yml
+++ b/.github/workflows/manual_article.yml
@@ -1,0 +1,99 @@
+name: Manual Article Generator
+
+on:
+  workflow_dispatch:
+    inputs:
+      topic:
+        description: 'Topic of the article'
+        required: false
+        type: string
+        default: 'Serverless computing in India: pros and cons'
+      publish:
+        description: 'Publish to Medium?'
+        required: false
+        type: boolean
+        default: false
+      tags:
+        description: 'Comma-separated tags (max 5)'
+        required: false
+        type: string
+        default: ''
+      audience:
+        description: 'Audience level'
+        required: false
+        type: choice
+        default: beginner
+        options:
+          - beginner
+          - intermediate
+          - advanced
+      tone:
+        description: 'Tone'
+        required: false
+        type: choice
+        default: practical
+        options:
+          - friendly
+          - professional
+          - practical
+          - conversational
+      model:
+        description: 'Perplexity model'
+        required: false
+        type: choice
+        default: sonar
+        options:
+          - sonar
+          - sonar-reasoning
+          - sonar-pro
+          - sonar-deep-research
+      minutes:
+        description: 'Estimated reading time'
+        required: false
+        type: number
+        default: 10
+      outline_depth:
+        description: 'Outline depth (integer)'
+        required: false
+        type: number
+        default: 3
+      include_code:
+        description: 'Include code snippets?'
+        required: false
+        type: boolean
+        default: true
+      status:
+        description: 'Medium publish status'
+        required: false
+        type: choice
+        default: draft
+        options:
+          - draft
+          - public
+          - unlisted
+      canonical_url:
+        description: 'Canonical URL (optional)'
+        required: false
+        type: string
+        default: ''
+
+concurrency:
+  group: auto-article
+  cancel-in-progress: false
+
+jobs:
+  generate:
+    uses: ./.github/workflows/generate.yml
+    secrets: inherit
+    with:
+      topic: ${{ github.event.inputs.topic }}
+      publish: ${{ github.event.inputs.publish }}
+      tags: ${{ github.event.inputs.tags }}
+      audience: ${{ github.event.inputs.audience }}
+      tone: ${{ github.event.inputs.tone }}
+      model: ${{ github.event.inputs.model }}
+      minutes: ${{ github.event.inputs.minutes }}
+      outline_depth: ${{ github.event.inputs.outline_depth }}
+      include_code: ${{ github.event.inputs.include_code }}
+      status: ${{ github.event.inputs.status }}
+      canonical_url: ${{ github.event.inputs.canonical_url }}


### PR DESCRIPTION
## Summary
- add reusable `generate.yml` workflow for article creation
- split scheduled and manual triggers into separate workflows

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898276b9df0832d8aca9f991be33e4c