### PR TITLE
Limit manual article workflow to 10 inputs

### DIFF
--- a/.github/workflows/manual_article.yml
+++ b/.github/workflows/manual_article.yml
@@ -71,11 +71,6 @@ on:
           - draft
           - public
           - unlisted
-      canonical_url:
-        description: 'Canonical URL (optional)'
-        required: false
-        type: string
-        default: ''
 
 concurrency:
   group: auto-article
@@ -96,4 +91,3 @@ jobs:
       outline_depth: ${{ github.event.inputs.outline_depth }}
       include_code: ${{ github.event.inputs.include_code }}
       status: ${{ github.event.inputs.status }}
-      canonical_url: ${{ github.event.inputs.canonical_url }}


### PR DESCRIPTION
## Summary
- Remove the `canonical_url` input from the manual article workflow to comply with GitHub's `workflow_dispatch` input limit.
- Update the generate job to use the remaining inputs only.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68982abda504832d89ff1cacb11bca5b