### PR TITLE
Fix YAML parsing for auto article workflow

### DIFF
--- a/.github/workflows/auto_article.yml
+++ b/.github/workflows/auto_article.yml
@@ -13,7 +13,8 @@ jobs:
     uses: ./.github/workflows/generate.yml
     secrets: inherit
     with:
-      topic: ${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}
+      topic: >-
+        ${{ vars.AUTO_TOPIC || 'Serverless computing in India: pros and cons' }}
       publish: ${{ vars.AUTO_PUBLISH || false }}
       tags: ${{ vars.AUTO_TAGS || '' }}
       audience: ${{ vars.AUTO_AUDIENCE || 'beginner' }}


### PR DESCRIPTION
## Summary
- fix invalid YAML syntax in auto_article workflow by using a block scalar for topic value

## Testing
- `python - <<'PY'
import yaml, pathlib
p=pathlib.Path('.github/workflows/auto_article.yml')
try:
    yaml.safe_load(p.read_text())
    print('YAML parsed successfully')
except Exception as e:
    print('Error:', e)
PY`
- `yamllint .github/workflows/auto_article.yml`


------
https://chatgpt.com/codex/tasks/task_e_68982ba38078832d90c93df867a52ea9