### PR TITLE
Add GitHub Action workflow and fix generation status

### DIFF
--- a/.github/actions/generate/action.yml
+++ b/.github/actions/generate/action.yml
@@ -1,3 +1,4 @@
+---
 name: Generate Article
 description: 'Set up Python and generate Medium article'
 
@@ -22,10 +23,12 @@ inputs:
     description: 'Tone (friendly|professional|practical|conversational)'
     required: false
     default: 'practical'
-  model:
-    description: 'Perplexity model (sonar|sonar-reasoning|sonar-pro|sonar-deep-research)'
-    required: false
-    default: 'sonar'
+    model:
+      description: >-
+        Perplexity model
+        (sonar|sonar-reasoning|sonar-pro|sonar-deep-research)
+      required: false
+      default: 'sonar'
   minutes:
     description: 'Estimated reading time'
     required: false
@@ -63,8 +66,10 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
+        key: >-
+          ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
+          ${{ hashFiles('requirements.txt') }}
+        restore-keys: >-
           ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-
 
     - name: Install dependencies
@@ -102,8 +107,10 @@ runs:
           TAGS_ARG="--tags $(echo $TAGS | tr ',' ' ')"
         fi
 
-        python -m app.cli \
-          --topic "$TOPIC" \
+        yoyo apply --database "$DATABASE_URL" db/migrations
+        ARTICLE_ID=$(python -m app.cli --db-url "$DATABASE_URL" \
+          plan --topic "$TOPIC" | awk '{print $4}')
+        python -m app.cli --db-url "$DATABASE_URL" generate "$ARTICLE_ID" \
           --audience "$AUDIENCE" \
           --tone "$TONE" \
           --model "$MODEL" \

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,81 +1,32 @@
-name: Generate Article
-
-on:
-  workflow_call:
+---
+name: Auto Article Generator
+'on':
+  workflow_dispatch:
     inputs:
       topic:
         description: 'Topic of the article'
         required: false
-        type: string
         default: 'Serverless computing in India: pros and cons'
       publish:
-        description: 'Publish to Medium?'
+        description: 'Publish to Medium (true or false)'
         required: false
-        type: boolean
-        default: false
+        default: 'false'
       tags:
-        description: 'Comma-separated tags (max 5)'
+        description: 'Comma-separated tags'
         required: false
-        type: string
         default: ''
-      audience:
-        description: 'Audience level'
-        required: false
-        type: string
-        default: beginner
-      tone:
-        description: 'Tone'
-        required: false
-        type: string
-        default: practical
-      model:
-        description: 'Perplexity model'
-        required: false
-        type: string
-        default: sonar
-      minutes:
-        description: 'Estimated reading time'
-        required: false
-        type: number
-        default: 10
-      outline_depth:
-        description: 'Outline depth (integer)'
-        required: false
-        type: number
-        default: 3
-      include_code:
-        description: 'Include code snippets?'
-        required: false
-        type: boolean
-        default: true
-      status:
-        description: 'Medium publish status'
-        required: false
-        type: string
-        default: draft
-      canonical_url:
-        description: 'Canonical URL (optional)'
-        required: false
-        type: string
-        default: ''
-
+  schedule:
+    - cron: '0 9 * * *'
 jobs:
   generate:
     runs-on: ubuntu-latest
-    env:
-      PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
-      MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
     steps:
       - uses: ./.github/actions/generate
         with:
           topic: ${{ inputs.topic }}
           publish: ${{ inputs.publish }}
           tags: ${{ inputs.tags }}
-          audience: ${{ inputs.audience }}
-          tone: ${{ inputs.tone }}
-          model: ${{ inputs.model }}
-          minutes: ${{ inputs.minutes }}
-          outline_depth: ${{ inputs.outline_depth }}
-          include_code: ${{ inputs.include_code }}
-          status: ${{ inputs.status }}
-          canonical_url: ${{ inputs.canonical_url }}
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/app/cli.py
+++ b/app/cli.py
@@ -136,13 +136,14 @@ def cmd_generate(args: argparse.Namespace) -> None:
         outfile.write_text(article_md, encoding="utf-8")
         print(f"[OK] Saved generated article to {outfile}")
 
+    db_status = "published" if args.publish else "generated"
     update_article(
         engine,
         args.id,
         markdown=article_md,
-        status=args.status,
+        status=db_status,
     )
-    print(f"[OK] Stored article {args.id} in database")
+    print(f"[OK] Stored article {args.id} in database with status '{db_status}'")
 
     if args.publish:
         meta = parse_frontmatter(article_md)


### PR DESCRIPTION
## Summary
- Track generated vs published articles in CLI by updating database status appropriately
- Provide composite GitHub Action and workflow to plan, generate, and publish articles on GitHub runners

## Testing
- `yamllint .github/actions/generate/action.yml .github/workflows/generate.yml`
- `python -m app.cli --help`
- `python -m app.cli --db-url sqlite:///blog.db plan --topic test`
- `python -m app.cli --db-url sqlite:///blog.db list`

------
https://chatgpt.com/codex/tasks/task_e_6898a065cb00832dbb03cbf72553b5e5