### PR TITLE
Add automatic article planning and publishing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Command-line tools to plan, generate and publish Medium articles driven by the P
 - List scheduled articles
 - Generate Markdown articles with Indian mini-projects and optional code snippets
 - Publish drafts or public posts directly to Medium
+- Automatically plan a series and publish the next article in one step
 
 ## Project layout
 ```
@@ -49,6 +50,7 @@ python -m app.cli plan-series  --db-key "$SUPABASE_KEY" --topic "Data Viz in Pyt
 python -m app.cli list         --db-key "$SUPABASE_KEY"
 python -m app.cli generate 1   --db-key "$SUPABASE_KEY" --publish --tags python medium
 python -m app.cli publish 1    --db-key "$SUPABASE_KEY" --status public --tags python medium
+python -m app.cli auto         --db-key "$SUPABASE_KEY" --topic "Data Viz in Python" --publish
 ```
 
 Key options for `generate`:
@@ -92,7 +94,7 @@ jobs:
           SUPABASE_URL:        ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY:        ${{ secrets.SUPABASE_KEY }}
         run: |
-          python -m app.cli generate 1 --db-key "$SUPABASE_KEY" --publish
+          python -m app.cli auto --db-key "$SUPABASE_KEY" --topic "Data Viz in Python" --publish
 ```
 
 Store the API keys and Supabase credentials as repository secrets.

--- a/app/db.py
+++ b/app/db.py
@@ -152,6 +152,24 @@ def list_planned_articles(client: Client) -> List[Dict[str, Any]]:
     return result.data or []
 
 
+def fetch_next_planned_article(client: Client) -> Optional[Dict[str, Any]]:
+    """Return the next planned article or ``None``.
+
+    This helper mirrors :func:`list_planned_articles` but only returns a single
+    row.  It keeps the selection logic in one place so callers that want the
+    "next" article don't have to re‑implement the Supabase query each time.
+    """
+    rows = (
+        client.table("articles")
+        .select("*")
+        .eq("status", "planned")
+        .order("scheduled_at", desc=False)
+        .limit(1)
+        .execute()
+    ).data
+    return rows[0] if rows else None
+
+
 __all__ = [
     "get_client",
     "init_db",
@@ -161,4 +179,5 @@ __all__ = [
     "fetch_article",
     "update_article",
     "list_planned_articles",
+    "fetch_next_planned_article",
 ]


### PR DESCRIPTION
## Summary
- add `fetch_next_planned_article` helper to pick next queued article
- introduce `auto` CLI command to plan a series when needed and generate/publish the next article
- refactor shared generation options into `add_generate_args`
- document new workflow and update GitHub Actions example

## Testing
- `python -m app.cli --help`
- `python -m app.cli auto --help`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898f5a98190832db822f69f7f8b01fd