### PR TITLE
Use auto command in workflow to create planned article when DB empty

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,4 +20,7 @@ jobs:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
         run: |
-          python -m app.cli generate 1 --db-key "$SUPABASE_KEY" --publish
+          python -m app.cli auto \
+            --db-key "$SUPABASE_KEY" \
+            --topic "Data Viz in Python" \
+            --publish


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to call `app.cli auto`
- auto plans a new series if no article exists before generation

## Testing
- `yamllint .github/workflows/generate.yml`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6898f99825d0832d82feacb0db3085f5