### PR TITLE
Handle fenced JSON in series plan

### DIFF
--- a/app/perplexity_generator.py
+++ b/app/perplexity_generator.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import os
 import json
+import re
 from typing import Literal, Optional, Dict, Any
 
 import requests
@@ -242,6 +243,11 @@ objects, each having the fields 'title' and 'summary'.
             raise PerplexityError(
                 f"Unexpected response shape from Perplexity: {data}"
             ) from exc
+
+        content = content.strip()
+        fenced = re.search(r"```(?:json)?\s*(.*?)\s*```", content, re.DOTALL)
+        if fenced:
+            content = fenced.group(1).strip()
 
         try:
             plan = json.loads(content)


### PR DESCRIPTION
## Summary
- Strip Markdown code fences from Perplexity responses before JSON parsing
- Import `re` for regex handling of fenced JSON blocks

## Testing
- `python -m py_compile app/perplexity_generator.py`
- `pytest` (no tests found)
- manual call to `generate_series_plan` with fenced JSON response

------
https://chatgpt.com/codex/tasks/task_e_6898fbe9e11c832dad987356b578f4c0