### PR TITLE
Ignore comments in frontmatter parsing

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -53,6 +53,9 @@ def parse_frontmatter(md: str) -> dict:
         raw = md[3:fence_end].strip()
         meta = {}
         for line in raw.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
             if ":" in line:
                 k, v = line.split(":", 1)
                 meta[k.strip()] = v.strip().strip('"').strip("'")

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,18 @@
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from app.cli import parse_frontmatter
+
+
+def test_basic_frontmatter_parsing():
+    md = """---\ntitle: "Hello"\nseo_description: 'desc'\n---\nbody"""
+    meta = parse_frontmatter(md)
+    assert meta == {"title": "Hello", "seo_description": "desc"}
+
+
+def test_ignores_comment_lines():
+    md = """---\n# just a comment\ntitle: Example\n# another: comment\n---\n"""
+    meta = parse_frontmatter(md)
+    assert meta == {"title": "Example"}


### PR DESCRIPTION
## Summary
- ignore commented and blank lines in Markdown frontmatter parser
- test frontmatter parser for comment handling and basic parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899efa21154832ab454990b92c1a285