### PR TITLE
chore: expand custom workflow inputs

### DIFF
--- a/.github/workflows/custom.yml
+++ b/.github/workflows/custom.yml
@@ -15,6 +15,26 @@ on:
         required: false
         type: boolean
         default: false
+      audience:
+        description: 'Audience level'
+        required: false
+        default: 'beginner'
+      tone:
+        description: 'Tone of the article'
+        required: false
+        default: 'tutorial'
+      minutes:
+        description: 'Target reading time in minutes'
+        required: false
+        default: '10'
+      outline_depth:
+        description: 'Outline depth (number of heading levels)'
+        required: false
+        default: '3'
+      goal:
+        description: 'Learning goal or objective'
+        required: false
+        default: ''
 
 jobs:
   generate:
@@ -41,6 +61,11 @@ jobs:
               --db-key "$SUPABASE_KEY" \
               --topic "${{ github.event.inputs.topic }}" \
               --posts "${{ github.event.inputs.posts }}" \
+              --audience "${{ github.event.inputs.audience }}" \
+              --tone "${{ github.event.inputs.tone }}" \
+              --minutes "${{ github.event.inputs.minutes }}" \
+              --outline-depth "${{ github.event.inputs.outline_depth }}" \
+              --goal "${{ github.event.inputs.goal }}" \
               $PUBLISH_FLAG
           done
 


### PR DESCRIPTION
## Summary
- allow customizing audience, tone, minutes, outline depth and goal via manual workflow
- keep workflow dispatch inputs to eight or fewer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a0d287280832aac8a1188dd41cc1a