### PR TITLE
Add workflow for scheduled series publishing

### DIFF
--- a/.github/workflows/series-delayed.yml
+++ b/.github/workflows/series-delayed.yml
@@ -1,0 +1,60 @@
+name: Scheduled series publisher
+
+on:
+  workflow_dispatch:
+    inputs:
+      topic:
+        description: 'Series topic'
+        required: true
+      posts:
+        description: 'Number of articles to plan'
+        required: false
+        default: '5'
+      gap_hours:
+        description: 'Hours between scheduled publications'
+        required: false
+        default: '24'
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  plan:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - name: Plan series in database
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        run: |
+          python -m app.cli plan-series \
+            --db-key "$SUPABASE_KEY" \
+            --topic "${{ github.event.inputs.topic }}" \
+            --posts "${{ github.event.inputs.posts }}" \
+            --gap-hours "${{ github.event.inputs.gap_hours }}"
+
+  generate:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - name: Generate and publish next scheduled article
+        env:
+          PERPLEXITY_API_KEY: ${{ secrets.PERPLEXITY_API_KEY }}
+          MEDIUM_TOKEN: ${{ secrets.MEDIUM_TOKEN }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_KEY: ${{ secrets.SUPABASE_KEY }}
+        run: |
+          python -m app.cli auto \
+            --db-key "$SUPABASE_KEY" \
+            --publish

--- a/app/db.py
+++ b/app/db.py
@@ -171,10 +171,12 @@ def fetch_next_planned_article(client: Client) -> Optional[Dict[str, Any]]:
     row.  It keeps the selection logic in one place so callers that want the
     "next" article don't have to re‑implement the Supabase query each time.
     """
+    now = datetime.utcnow().isoformat()
     rows = (
         client.table("articles")
         .select("*")
         .eq("status", "planned")
+        .lte("scheduled_at", now)
         .order("scheduled_at", desc=False)
         .limit(1)
         .execute()


### PR DESCRIPTION
## Summary
- add a workflow to persist a series plan and publish one article per scheduled run
- allow custom hour gaps between scheduled articles
- skip generation if next article's scheduled time is in the future

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a3161dc34832dac22dbe7bf1f9a4a