### PR TITLE
fix: serialize datetimes before supabase insert

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -104,7 +104,7 @@ def update_article(
 ) -> None:
     """Update fields on an existing article."""
     values = {
-        k: v
+        k: (v.isoformat() if isinstance(v, datetime) else v)
         for k, v in {
             "topic": topic,
             "status": status,
@@ -134,7 +134,7 @@ def save_article(
         "status": status,
         "markdown": markdown,
         "series_id": series_id,
-        "scheduled_at": scheduled_at,
+        "scheduled_at": scheduled_at.isoformat() if scheduled_at else None,
     }
     payload = {k: v for k, v in payload.items() if v is not None}
     insert_builder = client.table("articles").insert(payload)

--- a/tests/test_db_serialization.py
+++ b/tests/test_db_serialization.py
@@ -1,0 +1,40 @@
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db import save_article
+
+
+def test_save_article_serializes_datetime():
+    table_payload = {}
+
+    class DummyInsert:
+        def __init__(self, payload):
+            table_payload.update(payload)
+        def execute(self):
+            return SimpleNamespace(data=[{"id": 1}])
+
+    class DummyTable:
+        def insert(self, payload):
+            return DummyInsert(payload)
+
+    class DummyClient:
+        def __init__(self):
+            self._table = DummyTable()
+        def table(self, name):
+            assert name == "articles"
+            return self._table
+
+    client = DummyClient()
+    dt = datetime(2024, 1, 1, 2, 3, 4)
+    save_article(
+        client,
+        topic="topic",
+        status="planned",
+        markdown="",
+        scheduled_at=dt,
+    )
+    assert table_payload["scheduled_at"] == dt.isoformat()


### PR DESCRIPTION
## Summary
- ensure datetime fields are converted to ISO strings before inserting or updating articles
- add regression test for datetime serialisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a372e01e8832da3296c5e09885247