### PR TITLE
Add optional article refinement step

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -99,6 +99,7 @@ def update_article(
     topic: Optional[str] = None,
     status: Optional[str] = None,
     markdown: Optional[str] = None,
+    markdown_raw: Optional[str] = None,
     series_id: Optional[int] = None,
     scheduled_at: Optional[datetime] = None,
 ) -> None:
@@ -109,6 +110,7 @@ def update_article(
             "topic": topic,
             "status": status,
             "markdown": markdown,
+            "markdown_raw": markdown_raw,
             "series_id": series_id,
             "scheduled_at": scheduled_at,
         }.items()
@@ -125,6 +127,7 @@ def save_article(
     topic: str,
     status: str,
     markdown: str,
+    markdown_raw: Optional[str] = None,
     series_id: Optional[int] = None,
     scheduled_at: Optional[datetime] = None,
 ) -> int:
@@ -133,6 +136,7 @@ def save_article(
         "topic": topic,
         "status": status,
         "markdown": markdown,
+        "markdown_raw": markdown_raw,
         "series_id": series_id,
         "scheduled_at": scheduled_at.isoformat() if scheduled_at else None,
     }

--- a/app/perplexity_generator.py
+++ b/app/perplexity_generator.py
@@ -308,6 +308,33 @@ Write the article or series in {tone} tone for {audience_level} learners, timebo
                 f"Unexpected response shape from Perplexity: {data}"
             ) from exc
 
+    def refine_article(
+        self, markdown: str, model: PerpModel = "sonar"
+    ) -> str:
+        """Refine a Markdown draft by proofreading and tightening prose."""
+        system_message = (
+            "You are a meticulous technical editor. Improve clarity, grammar and "
+            "flow while preserving code blocks, links and overall meaning. "
+            "Return polished Markdown only."
+        )
+        user_prompt = f"Refine the following article:\n\n```markdown\n{markdown}\n```"
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_prompt},
+            ],
+            "temperature": 0.2,
+            "top_p": 0.9,
+        }
+        data = self._post("/chat/completions", payload)
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError) as exc:
+            raise PerplexityError(
+                f"Unexpected response shape from Perplexity: {data}"
+            ) from exc
+
     def generate_series_plan(
         self,
         topic: str,

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -1,0 +1,76 @@
+import argparse
+from app.perplexity_generator import PerplexityGenerator
+from app import cli
+
+
+def test_refine_article_monkeypatch(monkeypatch):
+    gen = PerplexityGenerator(api_key="key")
+
+    def fake_post(path, json):
+        return {"choices": [{"message": {"content": "better text"}}]}
+
+    monkeypatch.setattr(gen, "_post", fake_post)
+    result = gen.refine_article("raw text")
+    assert result == "better text"
+    assert result != "raw text"
+
+
+def test_cmd_generate_with_refine(monkeypatch):
+    raw_md = "raw"
+    refined_md = "refined"
+
+    class DummyGenerator:
+        def __init__(self, api_key):
+            pass
+
+        def generate_article(self, **kwargs):
+            return raw_md
+
+        def refine_article(self, markdown, model="sonar"):
+            assert markdown == raw_md
+            return refined_md
+
+    monkeypatch.setattr(cli, "PerplexityGenerator", DummyGenerator)
+    monkeypatch.setattr(cli, "render_diagrams_to_images", lambda md: (md, []))
+
+    captured = {}
+
+    def fake_update(client, article_id, **values):
+        captured["article_id"] = article_id
+        captured.update(values)
+
+    monkeypatch.setattr(cli, "update_article", fake_update)
+    monkeypatch.setattr(cli, "get_client", lambda key: object())
+    monkeypatch.setattr(cli, "init_db", lambda client: None)
+    monkeypatch.setattr(cli, "fetch_article", lambda client, id: {"id": id, "topic": "Topic"})
+
+    args = argparse.Namespace(
+        id=1,
+        db_key=None,
+        pplx_key="k",
+        audience="beginner",
+        tone="tutorial",
+        model="sonar",
+        no_code=False,
+        outline_depth=3,
+        minutes=10,
+        cta="CTA",
+        format="single article",
+        goal="",
+        stack_focus="",
+        timebox="~15-minute read",
+        diagram_language="python",
+        save_md=None,
+        publish=False,
+        refine=True,
+        tags=[],
+        status="draft",
+        canonical_url=None,
+        medium_token=None,
+    )
+
+    cli.cmd_generate(args)
+
+    assert captured["markdown_raw"] == raw_md
+    assert captured["markdown"] == refined_md
+    assert captured["status"] == "generated"


### PR DESCRIPTION
## Summary
- add `PerplexityGenerator.refine_article` for post-processing drafts
- support `--refine` flag to proofread and store raw vs refined copies
- persist raw markdown via new `markdown_raw` field
- test CLI integration and refinement behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689e4f052e44832aafdf7fff09cd911b