### PR TITLE
Add markdown_raw column and test serialization

### DIFF
--- a/db/migrations/001_create_tables.sql
+++ b/db/migrations/001_create_tables.sql
@@ -10,6 +10,7 @@ CREATE TABLE articles (
     topic VARCHAR NOT NULL,
     status VARCHAR NOT NULL,
     markdown TEXT,
+    markdown_raw TEXT,
     series_id INTEGER REFERENCES series(id),
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     scheduled_at TIMESTAMPTZ

--- a/db/migrations/002_add_markdown_raw.sql
+++ b/db/migrations/002_add_markdown_raw.sql
@@ -1,0 +1,6 @@
+-- Add markdown_raw column to articles
+ALTER TABLE articles ADD COLUMN markdown_raw TEXT;
+
+-- //@UNDO
+
+ALTER TABLE articles DROP COLUMN markdown_raw;

--- a/tests/test_db_serialization.py
+++ b/tests/test_db_serialization.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 
-from app.db import save_article
+from app.db import save_article, update_article, fetch_article
 
 
 def test_save_article_serializes_datetime():
@@ -38,3 +38,101 @@ def test_save_article_serializes_datetime():
         scheduled_at=dt,
     )
     assert table_payload["scheduled_at"] == dt.isoformat()
+
+
+def test_save_article_serializes_markdown_raw():
+    table_payload = {}
+
+    class DummyInsert:
+        def __init__(self, payload):
+            table_payload.update(payload)
+
+        def execute(self):
+            return SimpleNamespace(data=[{"id": 1}])
+
+    class DummyTable:
+        def insert(self, payload):
+            return DummyInsert(payload)
+
+    class DummyClient:
+        def __init__(self):
+            self._table = DummyTable()
+
+        def table(self, name):
+            assert name == "articles"
+            return self._table
+
+    client = DummyClient()
+    save_article(
+        client,
+        topic="topic",
+        status="planned",
+        markdown="",
+        markdown_raw="# raw",
+    )
+    assert table_payload["markdown_raw"] == "# raw"
+
+
+def test_update_article_serializes_markdown_raw():
+    table_payload = {}
+
+    class DummyUpdate:
+        def __init__(self, payload):
+            table_payload.update(payload)
+
+        def eq(self, field, value):
+            assert field == "id"
+            assert value == 1
+            return self
+
+        def execute(self):
+            return None
+
+    class DummyTable:
+        def update(self, payload):
+            return DummyUpdate(payload)
+
+    class DummyClient:
+        def __init__(self):
+            self._table = DummyTable()
+
+        def table(self, name):
+            assert name == "articles"
+            return self._table
+
+    client = DummyClient()
+    update_article(client, 1, markdown_raw="raw")
+    assert table_payload["markdown_raw"] == "raw"
+
+
+def test_fetch_article_returns_markdown_raw():
+    class DummySelect:
+        def __init__(self, data):
+            self._data = data
+
+        def eq(self, field, value):
+            assert field == "id"
+            assert value == 1
+            return self
+
+        def execute(self):
+            return SimpleNamespace(data=self._data)
+
+    class DummyTable:
+        def select(self, columns):
+            assert columns == "*"
+            return DummySelect([
+                {"id": 1, "markdown": "html", "markdown_raw": "# raw"}
+            ])
+
+    class DummyClient:
+        def __init__(self):
+            self._table = DummyTable()
+
+        def table(self, name):
+            assert name == "articles"
+            return self._table
+
+    client = DummyClient()
+    article = fetch_article(client, 1)
+    assert article["markdown_raw"] == "# raw"


### PR DESCRIPTION
## Summary
- include `markdown_raw` on article table and add incremental migration
- test serialization of `markdown_raw` when saving, updating, and fetching articles

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f6a824e7c832ab69106be4222fd99