### PR TITLE
Use yaml.safe_load for frontmatter

### DIFF
--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -16,3 +16,13 @@ def test_ignores_comment_lines():
     md = """---\n# just a comment\ntitle: Example\n# another: comment\n---\n"""
     meta = parse_frontmatter(md)
     assert meta == {"title": "Example"}
+
+
+def test_parses_lists_and_nested_values():
+    md = """---\nname: Example\ntags:\n  - a\n  - b\nextra:\n  nested:\n    value: 1\n---\n"""
+    meta = parse_frontmatter(md)
+    assert meta == {
+        "name": "Example",
+        "tags": ["a", "b"],
+        "extra": {"nested": {"value": 1}},
+    }

--- a/tests/test_parse_frontmatter.py
+++ b/tests/test_parse_frontmatter.py
@@ -10,12 +10,22 @@ def test_parses_valid_yaml_frontmatter():
     md = (
         "---\n"
         "title: Sample Post\n"
-        "tags: python, testing\n"
+        "tags:\n"
+        "  - python\n"
+        "  - testing\n"
+        "meta:\n"
+        "  author: Alice\n"
+        "  details:\n"
+        "    github: alice\n"
         "---\n"
         "Content"
     )
     meta = parse_frontmatter(md)
-    assert meta == {"title": "Sample Post", "tags": "python, testing"}
+    assert meta == {
+        "title": "Sample Post",
+        "tags": ["python", "testing"],
+        "meta": {"author": "Alice", "details": {"github": "alice"}},
+    }
 
 
 def test_handles_missing_frontmatter():
@@ -26,5 +36,11 @@ def test_handles_missing_frontmatter():
 
 def test_handles_malformed_frontmatter():
     md = "---\nmissing closing fence"
+    meta = parse_frontmatter(md)
+    assert meta == {}
+
+
+def test_returns_empty_dict_on_yaml_errors():
+    md = "---\n[unclosed\n---\n"
     meta = parse_frontmatter(md)
     assert meta == {}


### PR DESCRIPTION
## Summary
- replace manual frontmatter parsing with `yaml.safe_load`
- gracefully handle malformed or non-dict frontmatter
- expand tests to cover lists, nested values and malformed YAML

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f6d52f61c832a858bad13110241a8