### PR TITLE
Persist articles to Supabase and expose listing UI

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -162,6 +162,12 @@ def fetch_article(client: Client, article_id: int) -> Optional[Dict[str, Any]]:
     return data[0] if data else None
 
 
+def list_articles(client: Client) -> List[Dict[str, Any]]:
+    """Return all articles ordered by id."""
+    result = client.table("articles").select("*").order("id", desc=False).execute()
+    return result.data or []
+
+
 def list_planned_articles(client: Client) -> List[Dict[str, Any]]:
     """Return articles with status 'planned', ordered by scheduled_at."""
     result = (
@@ -201,6 +207,7 @@ __all__ = [
     "plan_article",
     "save_article",
     "fetch_article",
+    "list_articles",
     "update_article",
     "list_planned_articles",
     "fetch_next_planned_article",

--- a/app/templates/article.html
+++ b/app/templates/article.html
@@ -2,11 +2,14 @@
 
 {% block content %}
   <h2>{{ topic }}</h2>
-  <form method="post" action="{{ url_for('publish_article') }}">
+  <form method="post" action="{{ form_action }}">
     <input type="hidden" name="topic" value="{{ topic }}" />
+    {% if article_id %}
+    <input type="hidden" name="article_id" value="{{ article_id }}" />
+    {% endif %}
     <div class="mb-3">
       <textarea class="form-control" name="content" rows="15">{{ content }}</textarea>
     </div>
-    <button type="submit" class="btn btn-success">Publish Article</button>
+    <button type="submit" class="btn btn-success">{{ button_label }}</button>
   </form>
 {% endblock %}

--- a/app/templates/articles.html
+++ b/app/templates/articles.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+
+{% block content %}
+  <h2>Stored Articles</h2>
+  <ul>
+    {% for article in articles %}
+      <li><a href="{{ url_for('edit_article', article_id=article['id']) }}">{{ article['topic'] }}</a></li>
+    {% else %}
+      <li>No articles found.</li>
+    {% endfor %}
+  </ul>
+{% endblock %}

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,39 @@
+import app.web as web
+
+def test_create_article(monkeypatch):
+    class Gen:
+        def generate_article(self, topic, audience_level, tone, goal):
+            return "generated content"
+
+    monkeypatch.setattr(web, "get_generator", lambda: Gen())
+    monkeypatch.setattr(web, "get_db_client", lambda: object())
+    saved = {}
+
+    def fake_save_article(client, **kwargs):
+        saved.update(kwargs)
+        return 1
+
+    monkeypatch.setattr(web, "save_article", fake_save_article)
+
+    client = web.app.test_client()
+    resp = client.post(
+        "/create",
+        data={"topic": "Foo", "audience_level": "beginner", "tone": "casual", "goal": ""},
+    )
+    assert resp.status_code == 200
+    assert b"generated content" in resp.data
+    assert saved["topic"] == "Foo"
+
+
+def test_list_articles(monkeypatch):
+    monkeypatch.setattr(web, "get_db_client", lambda: object())
+
+    def fake_list(client):
+        return [{"id": 1, "topic": "Foo"}]
+
+    monkeypatch.setattr(web, "list_articles", fake_list)
+
+    client = web.app.test_client()
+    resp = client.get("/articles")
+    assert resp.status_code == 200
+    assert b"Foo" in resp.data


### PR DESCRIPTION
## Summary
- Load Flask `secret_key` from `AUTO_BLOG_SECRET`
- Store generated articles in Supabase and expose list/edit routes
- Add minimal tests for article creation and listing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f70163144832aafba30242ef6a417