### PR TITLE
Store diagram images and prepare Medium-safe URLs

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -182,7 +182,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
         else article_md_raw
     )
 
-    article_md, diagram_paths = render_diagrams_to_images(article_md)
+    article_md, _ = render_diagrams_to_images(article_md, article_id=args.id)
 
     if args.save_md:
         outfile = Path(args.save_md)
@@ -208,12 +208,6 @@ def cmd_generate(args: argparse.Namespace) -> None:
         tags = (meta_tags or args.tags)[:5]
 
         publisher = MediumPublisher(token=args.medium_token)
-        for path in diagram_paths:
-            try:
-                url = publisher.upload_image(path)
-                article_md = article_md.replace(path, url)
-            except Exception as exc:  # pragma: no cover - network failures
-                print(f"[WARN] Failed to upload image {path}: {exc}")
         resp = publisher.publish_article(
             title=title,
             content_markdown=article_md,
@@ -238,7 +232,7 @@ def cmd_publish(args: argparse.Namespace) -> None:
         raise SystemExit(f"Article {args.id} has no markdown to publish")
     topic = row["topic"]
 
-    article_md, diagram_paths = render_diagrams_to_images(article_md)
+    article_md, _ = render_diagrams_to_images(article_md, article_id=args.id)
 
     meta = parse_frontmatter(article_md)
     title = meta.get("title") or f"{topic} — with Indian Mini Projects by Praveen"
@@ -247,12 +241,6 @@ def cmd_publish(args: argparse.Namespace) -> None:
     tags = (meta_tags or args.tags)[:5]
 
     publisher = MediumPublisher(token=args.medium_token)
-    for path in diagram_paths:
-        try:
-            url = publisher.upload_image(path)
-            article_md = article_md.replace(path, url)
-        except Exception as exc:  # pragma: no cover - network failures
-            print(f"[WARN] Failed to upload image {path}: {exc}")
     resp = publisher.publish_article(
         title=title,
         content_markdown=article_md,

--- a/db/__init__.py
+++ b/db/__init__.py
@@ -1,0 +1,3 @@
+"""Database helper package."""
+
+__all__ = ["save_article_image"]

--- a/db/helpers.py
+++ b/db/helpers.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import uuid
+from app.db import get_client
+
+try:
+    from supabase.client import Client  # type: ignore
+except Exception:  # pragma: no cover - supabase not installed in tests
+    Client = object  # type: ignore
+
+
+BUCKET_NAME = "article-images"
+
+
+def save_article_image(article_id: int, diagram_type: str, image_bytes: bytes) -> str:
+    """Upload an article diagram image to Supabase storage and record metadata.
+
+    Parameters
+    ----------
+    article_id:
+        Identifier of the article the diagram belongs to.
+    diagram_type:
+        Name or type of diagram being stored.
+    image_bytes:
+        Binary image data to store.
+
+    Returns
+    -------
+    str
+        Public URL of the uploaded image.
+    """
+    client: Client = get_client()
+    file_name = f"{article_id}_{uuid.uuid4().hex}.png"
+    storage_path = f"{article_id}/{file_name}"
+    bucket = client.storage.from_(BUCKET_NAME)
+    bucket.upload(storage_path, image_bytes)
+    public_url = bucket.get_public_url(storage_path)
+    client.table("article_images").insert(
+        {
+            "article_id": article_id,
+            "diagram_type": diagram_type,
+            "image_url": public_url,
+        }
+    ).execute()
+    return public_url

--- a/db/migrations/004_create_article_images.sql
+++ b/db/migrations/004_create_article_images.sql
@@ -1,0 +1,8 @@
+-- Create table for storing diagram images associated with articles
+CREATE TABLE IF NOT EXISTS article_images (
+    id SERIAL PRIMARY KEY,
+    article_id INTEGER REFERENCES articles(id),
+    diagram_type TEXT,
+    image_url TEXT,
+    created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/tests/test_diagram_utils.py
+++ b/tests/test_diagram_utils.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from app import diagram_utils
 
 
-def test_render_diagrams_to_images(tmp_path, monkeypatch):
+def test_render_diagrams_to_images(monkeypatch):
     md = (
         "Intro\n\n"  # simple markdown with diagrams code block
         "```python\nfrom diagrams import Diagram\nwith Diagram('Test'):\n    pass\n```\n"
@@ -16,8 +16,21 @@ def test_render_diagrams_to_images(tmp_path, monkeypatch):
 
     monkeypatch.setattr(diagram_utils.subprocess, "run", fake_run)
 
-    new_md, paths = diagram_utils.render_diagrams_to_images(md, image_dir=tmp_path)
+    captured = {}
 
-    assert "![Diagram 1]" in new_md
-    assert len(paths) == 1
-    assert Path(paths[0]).exists()
+    def fake_save(article_id, diagram_type, image_bytes):
+        captured["article_id"] = article_id
+        captured["diagram_type"] = diagram_type
+        captured["image_bytes"] = image_bytes
+        return "https://storage.example/img.png"
+
+    monkeypatch.setattr(diagram_utils, "save_article_image", fake_save)
+
+    new_md, urls = diagram_utils.render_diagrams_to_images(md, article_id=1)
+
+    assert new_md.strip().startswith("Intro")
+    assert "![Test](https://storage.example/img.png)" in new_md
+    assert captured["article_id"] == 1
+    assert captured["diagram_type"] == "Test"
+    assert captured["image_bytes"] == b"fake"
+    assert urls == ["https://storage.example/img.png"]

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -31,7 +31,7 @@ def test_cmd_generate_with_refine(monkeypatch):
             return refined_md
 
     monkeypatch.setattr(cli, "PerplexityGenerator", DummyGenerator)
-    monkeypatch.setattr(cli, "render_diagrams_to_images", lambda md: (md, []))
+    monkeypatch.setattr(cli, "render_diagrams_to_images", lambda md, article_id: (md, []))
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- add `article_images` table migration and helpers for storing uploaded diagram images in Supabase
- render diagram code blocks to images and save them, replacing blocks with hosted image links
- ensure Medium publishing uploads any non-Medium images and rewrites links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f73b2780c832a9c4a55080eda472b