### PR TITLE
feat: add Supabase storage helper

### DIFF
--- a/app/diagram_utils.py
+++ b/app/diagram_utils.py
@@ -10,7 +10,7 @@ from db.helpers import save_article_image
 
 # Regular expression to capture Python fenced code blocks
 CODE_BLOCK_RE = re.compile(r"```python\n(.*?)```", re.DOTALL)
-DIAGRAM_NAME_RE = re.compile(r"Diagram\(['\"]([^'\"]+)['\"]")
+DIAGRAM_TYPE_RE = re.compile(r"Diagram\(['\"]([^'\"]+)['\"]")
 
 
 def _execute_diagram(code: str) -> Tuple[bytes, str]:
@@ -63,11 +63,11 @@ def render_diagrams_to_images(md: str, article_id: int) -> Tuple[str, List[str]]
         if "from diagrams" in code or "Diagram(" in code:
             try:
                 image_bytes, _ = _execute_diagram(code)
-                name_match = DIAGRAM_NAME_RE.search(code)
-                diagram_name = name_match.group(1) if name_match else f"Diagram {idx}"
-                url = save_article_image(article_id, diagram_name, image_bytes)
+                name_match = DIAGRAM_TYPE_RE.search(code)
+                diagram_type = name_match.group(1) if name_match else f"Diagram {idx}"
+                url = save_article_image(article_id, diagram_type, image_bytes)
                 image_urls.append(url)
-                out_md_parts.append(f"![{diagram_name}]({url})")
+                out_md_parts.append(f"![{diagram_type}]({url})")
             except Exception:
                 out_md_parts.append(match.group(0))
         else:

--- a/db/helpers.py
+++ b/db/helpers.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 import uuid
 from app.db import get_client
+from db.storage import upload_image
 
 try:
     from supabase.client import Client  # type: ignore
 except Exception:  # pragma: no cover - supabase not installed in tests
     Client = object  # type: ignore
-
-
-BUCKET_NAME = "article-images"
 
 
 def save_article_image(article_id: int, diagram_type: str, image_bytes: bytes) -> str:
@@ -32,9 +30,7 @@ def save_article_image(article_id: int, diagram_type: str, image_bytes: bytes) -
     client: Client = get_client()
     file_name = f"{article_id}_{uuid.uuid4().hex}.png"
     storage_path = f"{article_id}/{file_name}"
-    bucket = client.storage.from_(BUCKET_NAME)
-    bucket.upload(storage_path, image_bytes)
-    public_url = bucket.get_public_url(storage_path)
+    public_url = upload_image(image_bytes, storage_path)
     client.table("article_images").insert(
         {
             "article_id": article_id,

--- a/db/storage.py
+++ b/db/storage.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+"""Helper functions for interacting with Supabase storage."""
+
+from app.db import get_client
+
+try:  # pragma: no cover - supabase not installed in tests
+    from supabase.client import Client  # type: ignore
+except Exception:  # pragma: no cover - supabase not installed in tests
+    Client = object  # type: ignore
+
+BUCKET_NAME = "auto_blog"
+
+
+def upload_image(image_bytes: bytes, file_name: str) -> str:
+    """Upload image bytes to Supabase storage and return a public URL.
+
+    Parameters
+    ----------
+    image_bytes:
+        Raw image data to upload.
+    file_name:
+        Destination path within the storage bucket.
+    """
+    client: Client = get_client()
+    bucket = client.storage.from_(BUCKET_NAME)
+    bucket.upload(file_name, image_bytes)
+    return bucket.get_public_url(file_name)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,66 @@
+from db import storage, helpers
+
+
+def test_upload_image(monkeypatch):
+    class FakeBucket:
+        def __init__(self):
+            self.path = None
+            self.data = None
+        def upload(self, path, data):
+            self.path = path
+            self.data = data
+        def get_public_url(self, path):
+            return f"https://cdn.example/{path}"
+
+    class FakeStorage:
+        def __init__(self):
+            self.bucket = FakeBucket()
+        def from_(self, bucket_name):
+            assert bucket_name == storage.BUCKET_NAME
+            return self.bucket
+
+    class FakeClient:
+        def __init__(self):
+            self.storage = FakeStorage()
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(storage, "get_client", lambda: fake_client)
+
+    url = storage.upload_image(b"img", "1/file.png")
+    assert fake_client.storage.bucket.path == "1/file.png"
+    assert fake_client.storage.bucket.data == b"img"
+    assert url == "https://cdn.example/1/file.png"
+
+
+def test_save_article_image(monkeypatch):
+    uploaded = {}
+    def fake_upload(image_bytes, path):
+        uploaded["image_bytes"] = image_bytes
+        uploaded["path"] = path
+        return f"https://cdn.example/{path}"
+
+    inserted = {}
+    class FakeTable:
+        def insert(self, data):
+            inserted.update(data)
+            class Exec:
+                def execute(self_inner):
+                    return None
+            return Exec()
+
+    class FakeClient:
+        def table(self, name):
+            inserted["table"] = name
+            return FakeTable()
+
+    monkeypatch.setattr(helpers, "get_client", lambda: FakeClient())
+    monkeypatch.setattr(helpers, "upload_image", fake_upload)
+
+    url = helpers.save_article_image(1, "foo", b"bytes")
+    assert uploaded["image_bytes"] == b"bytes"
+    assert uploaded["path"].startswith("1/")
+    assert inserted["table"] == "article_images"
+    assert inserted["article_id"] == 1
+    assert inserted["diagram_type"] == "foo"
+    assert inserted["image_url"] == url
+    assert url.startswith("https://cdn.example/1/")


### PR DESCRIPTION
## Summary
- add `db.storage.upload_image` to push bytes to the `auto_blog` bucket and return a public URL
- use `upload_image` when saving diagram images and swap markdown blocks with `![diagram_type](url)`
- test storage uploads and URL substitution with mocked Supabase client

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689f7c71ea58832abd2e38d976be7b9f