### PR TITLE
feat: support diagram sections in article generator

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -175,6 +175,7 @@ def cmd_generate(args: argparse.Namespace) -> None:
         stack_focus=stack_focus,
         timebox=args.timebox,
         diagram_language=args.diagram_language,
+        diagram_sections=args.diagram_sections,
     )
     article_md = (
         generator.refine_article(article_md_raw, model=args.model)
@@ -375,6 +376,13 @@ def add_generate_args(p: argparse.ArgumentParser) -> None:
         "--diagram-language",
         default="python",
         help="Language for diagram code blocks (e.g. 'python', 'mermaid').",
+    )
+    p.add_argument(
+        "--diagram-section",
+        action="append",
+        dest="diagram_sections",
+        default=[],
+        help="Section name requiring its own diagram (repeatable).",
     )
     p.add_argument(
         "--refine",

--- a/app/perplexity_generator.py
+++ b/app/perplexity_generator.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import os
 import json
 import re
-from typing import Literal, Optional, Dict, Any
+from typing import Literal, Optional, Dict, Any, List
 
 import requests
 from requests.adapters import HTTPAdapter, Retry
@@ -187,6 +187,7 @@ Respond ONLY with a JSON array of strings.
         stack_focus: str = "",
         timebox: str = "~15-minute read",
         diagram_language: str = "python",
+        diagram_sections: Optional[List[str]] = None,
     ) -> str:
         """
         Generate an article in Markdown format around a given topic.
@@ -232,6 +233,9 @@ Respond ONLY with a JSON array of strings.
             Optional duration such as ``"30-day bootcamp"`` or ``"~15-minute read"``.
         diagram_language:
             Language to use for diagram code blocks (e.g. ``"python"`` or ``"mermaid"``).
+        diagram_sections:
+            Optional list of section names that should each include a
+            dedicated {diagram_language} diagram code block.
 
         Returns
         -------
@@ -243,6 +247,13 @@ Respond ONLY with a JSON array of strings.
             "Produce publish‑ready Markdown articles with runnable code, "
             "practical projects and viral, shareable hooks."
         )
+        section_instruction = ""
+        if diagram_sections:
+            section_lines = "\n".join(
+                f'For section "{section}", include a separate {diagram_language} `diagrams` code block.'
+                for section in diagram_sections
+            )
+            section_instruction = f"\n{section_lines}"
         user_prompt = f"""
 Role & Goal
 Act as a passionate senior developer, tech mentor, and content curator across DSA, ML, AI, Go (Golang), Java, React, AWS, and System Design. Use Python only when generating `diagrams` library code; otherwise choose languages that best suit each topic. Create either a single deep‑dive article or a multi‑part bootcamp series for Medium and similar platforms. Make it hands‑on, industry‑relevant, beginner‑friendly (explain like I’m 5), and fully attributed.
@@ -276,10 +287,10 @@ Industry Use Cases & Hiring Signals
 Next Steps / Extensions
 References & Credits
 
-Diagram Requirements (Step 3)
-Provide {diagram_language} `diagrams` library code blocks and describe how to render them. Use multiple small diagrams where helpful.
+ Diagram Requirements (Step 3)
+ Provide {diagram_language} `diagrams` library code blocks and describe how to render them. Use multiple small diagrams where helpful.{section_instruction}
 
-Hands‑On & Real‑World (Step 4)
+ Hands‑On & Real‑World (Step 4)
 Include 2–3 production‑style examples mapping to {stack_focus}. Show working code in appropriate languages and include infra/deploy notes where relevant. Add metrics/observability hints.
 
 Quality Bar (Step 5)

--- a/tests/test_diagram_sections.py
+++ b/tests/test_diagram_sections.py
@@ -1,0 +1,20 @@
+import pytest
+
+from app.perplexity_generator import PerplexityGenerator
+
+
+def test_diagram_sections_in_prompt(monkeypatch):
+    captured = {}
+
+    def fake_post(self, path, json):
+        captured['payload'] = json
+        return {'choices': [{'message': {'content': 'dummy'}}]}
+
+    monkeypatch.setattr(PerplexityGenerator, '_post', fake_post)
+
+    gen = PerplexityGenerator(api_key='test')
+    gen.generate_article('Sample', diagram_language='mermaid', diagram_sections=['Overview', 'Data Flow'])
+
+    user_prompt = captured['payload']['messages'][1]['content']
+    assert 'For section "Overview", include a separate mermaid `diagrams` code block.' in user_prompt
+    assert 'For section "Data Flow", include a separate mermaid `diagrams` code block.' in user_prompt

--- a/tests/test_refine.py
+++ b/tests/test_refine.py
@@ -60,6 +60,7 @@ def test_cmd_generate_with_refine(monkeypatch):
         stack_focus="",
         timebox="~15-minute read",
         diagram_language="python",
+        diagram_sections=[],
         save_md=None,
         publish=False,
         refine=True,


### PR DESCRIPTION
## Summary
- support targeted diagram sections in `generate_article`
- expose repeatable `--diagram-section` CLI option
- test diagram section propagation into prompt

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_689f84cb60e8832aa82ecae7afc70ee3