### PR TITLE
Ensure unique diagram fallback names and enhance tests

### DIFF
--- a/app/diagram_utils.py
+++ b/app/diagram_utils.py
@@ -56,15 +56,20 @@ def render_diagrams_to_images(md: str, article_id: int) -> Tuple[str, List[str]]
     out_md_parts: List[str] = []
     image_urls: List[str] = []
     last_end = 0
+    diagram_count = 0
 
-    for idx, match in enumerate(CODE_BLOCK_RE.finditer(md), start=1):
+    for match in CODE_BLOCK_RE.finditer(md):
         out_md_parts.append(md[last_end:match.start()])
         code = match.group(1).strip()
         if "from diagrams" in code or "Diagram(" in code:
             try:
                 image_bytes, _ = _execute_diagram(code)
                 name_match = DIAGRAM_TYPE_RE.search(code)
-                diagram_type = name_match.group(1) if name_match else f"Diagram {idx}"
+                if name_match:
+                    diagram_type = name_match.group(1)
+                else:
+                    diagram_count += 1
+                    diagram_type = f"Diagram {diagram_count}"
                 url = save_article_image(article_id, diagram_type, image_bytes)
                 image_urls.append(url)
                 out_md_parts.append(f"![{diagram_type}]({url})")

--- a/tests/test_diagram_utils.py
+++ b/tests/test_diagram_utils.py
@@ -34,3 +34,36 @@ def test_render_diagrams_to_images(monkeypatch):
     assert captured["diagram_type"] == "Test"
     assert captured["image_bytes"] == b"fake"
     assert urls == ["https://storage.example/img.png"]
+
+
+def test_render_multiple_diagrams_with_fallback(monkeypatch):
+    md = (
+        "Intro\n\n"
+        "```python\nfrom diagrams import Diagram\nwith Diagram():\n    pass\n```\n\n"
+        "```python\nfrom diagrams import Diagram\nwith Diagram():\n    pass\n```\n"
+    )
+
+    def fake_run(cmd, input, text, cwd, check, env):
+        Path(cwd, "dummy.png").write_bytes(b"fake")
+        return None
+
+    monkeypatch.setattr(diagram_utils.subprocess, "run", fake_run)
+
+    saved = []
+
+    def fake_save(article_id, diagram_type, image_bytes):
+        saved.append((article_id, diagram_type, image_bytes))
+        return f"https://storage.example/img{len(saved)}.png"
+
+    monkeypatch.setattr(diagram_utils, "save_article_image", fake_save)
+
+    new_md, urls = diagram_utils.render_diagrams_to_images(md, article_id=1)
+
+    assert "![Diagram 1](https://storage.example/img1.png)" in new_md
+    assert "![Diagram 2](https://storage.example/img2.png)" in new_md
+    assert urls == [
+        "https://storage.example/img1.png",
+        "https://storage.example/img2.png",
+    ]
+    assert saved[0][1] == "Diagram 1"
+    assert saved[1][1] == "Diagram 2"


### PR DESCRIPTION
## Summary
- Use a dedicated diagram counter so unnamed diagrams fall back to unique titles like "Diagram 1" and "Diagram 2"
- Add tests covering multiple diagram code blocks and distinct image link generation
- Verify storage helper correctly inserts multiple diagram_type records

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689f8869dc30832ab71857e7d0465c97