### PR TITLE
Handle string scheduled_at in list command

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -149,7 +149,15 @@ def cmd_list(args: argparse.Namespace) -> None:
     rows = list_planned_articles(client)
     for row in rows:
         sched = row.get("scheduled_at")
-        sched_str = sched.isoformat() if sched else "-"
+        sched_dt = None
+        if isinstance(sched, str):
+            try:
+                sched_dt = datetime.fromisoformat(sched)
+            except ValueError:
+                sched_dt = None
+        else:
+            sched_dt = sched
+        sched_str = sched_dt.isoformat() if sched_dt else (sched if isinstance(sched, str) else "-")
         print(f"{row['id']}: {row['topic']} (scheduled {sched_str})")
 
 

--- a/tests/test_cli_list.py
+++ b/tests/test_cli_list.py
@@ -1,0 +1,16 @@
+import argparse
+import os
+import sys
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app import cli
+
+
+def test_cmd_list_handles_string_schedule(monkeypatch, capsys):
+    rows = [{"id": 1, "topic": "t", "scheduled_at": "2024-01-01T00:00:00"}]
+    monkeypatch.setattr(cli, "get_client", lambda db_key: None)
+    monkeypatch.setattr(cli, "init_db", lambda client: None)
+    monkeypatch.setattr(cli, "list_planned_articles", lambda client: rows)
+    cli.cmd_list(argparse.Namespace(db_key=None))
+    assert "2024-01-01T00:00:00" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- handle scheduled_at values provided as strings in list command
- add regression test for scheduled_at formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68b191822ad0832ab133c0b02d13139b